### PR TITLE
Improve theme support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # myuw-search versions
 
+## 1.1.9
+
+### Added
+
+* Now supports setting the `--myuw-search-border` CSS variable to better support theming.
+
+## Changed
+
+* Give search toggle button a margin when form is expanded.
+
 ## 1.1.8
 
 This patch adds attribute mirroring so that changes to observed attributes that occur _after_ the initial load are correctly reflected in the component.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ document.getElementById('search').callback = (value) => {
 - **buttonLabel (button-label)**: Text to use for the aria-label of the search button
 - **icon (icon)**: Text name of the material icon to use for the submit button ("search" by default)
 
+### Custom CSS properties
+
+- **--myuw-search-border**: Used to set the border color of the search component (to support themes with light background colors). Defaults to `none`.
+- **--myuw-app-bar-color**: Used by to set the color of the search button icon on small screens. Defaults to white. 
+
 ## Development and contribution
 
 To run the demo app locally and test the component, run the following commands:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-search",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-search",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "A material search field made for use with MyUW web components",
   "module": "dist/myuw-search.min.mjs",
   "browser": "dist/myuw-search.min.js",

--- a/src/myuw-search.html
+++ b/src/myuw-search.html
@@ -4,17 +4,22 @@
     :host {
         display: flex;
         flex: auto;
+        border: var(--myuw-search-border, none);
+        border-radius: 5px;
     }
 
     :host([hidden]) {
         display: none;
     }
 
+    myuw-search {
+        border: var(--myuw-search-border, none);
+    }
+
     #form {
         display: flex;
         flex: auto;
         flex-direction: row;
-        padding: 0 18px;
         margin: 0;
     }
 
@@ -35,13 +40,19 @@
         border-top-right-radius: 5px;
         border-bottom-right-radius: 5px;
         border: none;
-        border-left: 1px solid #333;
+        border-left: 1px solid;
+        border-color: var(--myuw-search-border-color, rgba(0,0,0,0.5));
         color: #333;
         background: #fff;
         width: 56px;
         font-size: 1.8rem;
         margin: 0;
         cursor: pointer;
+        transition: background-color 0.2s ease-in-out;
+    }
+
+    #submit:hover {
+        background-color: #ebeaea;
     }
 
     #toggle {

--- a/src/myuw-search.html
+++ b/src/myuw-search.html
@@ -41,7 +41,7 @@
         border-bottom-right-radius: 5px;
         border: none;
         border-left: 1px solid;
-        border-color: var(--myuw-search-border-color, rgba(0,0,0,0.5));
+        border-color: rgba(0,0,0,0.5);
         color: #333;
         background: #fff;
         width: 56px;
@@ -120,6 +120,7 @@
         #form[expanded] #toggle {
             position: absolute;
             right: 0;
+            margin: 0 6px;
         }
         #form[expanded] #iconToggle {
             color: #000;


### PR DESCRIPTION
**In this PR**:
- Consume a CSS variable for setting a border on the search box (`--myuw-search-border`) to support themes with lighter backgrounds
- Remove padding on search form so appearance is the same with or without borders
- Add margin to search toggle button when the search form is expanded