### PR TITLE
Use custom events instead of manual callback

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
 
         <script>
             // Add a callback to the serach component
-            document.getElementById('search').addEventListener('search', (event) => {
+            document.getElementById('search').addEventListener('myuw-search', (event) => {
                 var value = event.detail.value;
                 var label = document.getElementById('searchLabel');
                 var searchValue = document.getElementById('searchValue');

--- a/index.html
+++ b/index.html
@@ -139,13 +139,14 @@
 
         <script>
             // Add a callback to the serach component
-            document.getElementById('search').callback = (value) => {
+            document.getElementById('search').addEventListener('search', (event) => {
+                var value = event.detail.value;
                 var label = document.getElementById('searchLabel');
                 var searchValue = document.getElementById('searchValue');
                 
                 label.innerText = 'You searched for: ';
                 searchValue.innerText = '"' + value + '"';
-            }
+            }, false);
 
             function updateSearchBar() {
                 // Get all elements

--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
 
         <script>
             // Add a callback to the serach component
-            document.getElementById('search').addEventListener('myuw-search', (event) => {
+            document.body.addEventListener('myuw-search', (event) => {
                 var value = event.detail.value;
                 var label = document.getElementById('searchLabel');
                 var searchValue = document.getElementById('searchValue');

--- a/src/myuw-search.js
+++ b/src/myuw-search.js
@@ -159,3 +159,24 @@ MyUWSearch.template = (function template(src) {
 })(tpl);
 
 window.customElements.define('myuw-search', MyUWSearch);
+
+/**
+ * Polyfill for supporting the CustomEvent constructor in IE9+
+ * From: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
+ */
+(function () {
+    if (typeof window.CustomEvent === 'function') {
+        return false;
+    }
+
+    function CustomEvent (event, params) {
+        params = params || { bubbles: false, cancelable: false, detail: undefined };
+        var evt = document.createEvent( 'CustomEvent' );
+        evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail);
+        return evt;
+    }
+
+    CustomEvent.prototype = window.Event.prototype;
+
+    window.CustomEvent = CustomEvent;
+})();

--- a/src/myuw-search.js
+++ b/src/myuw-search.js
@@ -117,6 +117,13 @@ export class MyUWSearch extends HTMLElement {
     submitSearch(event) {
         event.preventDefault();
         event.stopPropagation();
+
+        // Using `callback` property:
+        if (this.callback && typeof this.callback === 'function') {
+            this.callback(this.$input.value);
+        }
+
+        // Emitting a custom event:
         var customEvent = new CustomEvent('search', {
             detail: {
                 value: this.$input.value

--- a/src/myuw-search.js
+++ b/src/myuw-search.js
@@ -125,6 +125,7 @@ export class MyUWSearch extends HTMLElement {
 
         // Emitting a custom event:
         var customEvent = new CustomEvent('myuw-search', {
+            bubbles: true,
             detail: {
                 value: this.$input.value
             }

--- a/src/myuw-search.js
+++ b/src/myuw-search.js
@@ -117,9 +117,12 @@ export class MyUWSearch extends HTMLElement {
     submitSearch(event) {
         event.preventDefault();
         event.stopPropagation();
-        if (this.callback && typeof this.callback === 'function') {
-            this.callback( this.$input.value );
-        }
+        var customEvent = new CustomEvent('search', {
+            detail: {
+                value: this.$input.value
+            }
+        });
+        this.dispatchEvent(customEvent);
     }
 
     /**

--- a/src/myuw-search.js
+++ b/src/myuw-search.js
@@ -124,7 +124,7 @@ export class MyUWSearch extends HTMLElement {
         }
 
         // Emitting a custom event:
-        var customEvent = new CustomEvent('search', {
+        var customEvent = new CustomEvent('myuw-search', {
             detail: {
                 value: this.$input.value
             }


### PR DESCRIPTION
The current API for listening to search events involves binding a callback function to the `<myuw-search>` element. This limits the number of event listeners to 1 and is a less common pattern for observing DOM events.

This PR proposes listening for search events using the `addEventListener` method of the `<myuw-search>` element. This allows for multiple listeners and reflects how many native DOM elements expose events. With this PR the search component emits a `search` event whenever the user submits the search form:

```js
// Listening for event on the #search element:
document.querySelector('#search').addEventListener('myuw-search', event => { /* ... */ });

// Using event bubbling to listen for event on the document body:
document.body.addEventListener('myuw-search', event => { /* ... */ });
```

The 'myuw-search' event is custom to the `<myuw-search>` element and a short polyfill for using the custom event API on IE9+ is included in this PR.