### PR TITLE
Update contributing docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,5 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.md]
+max_line_length=80

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,21 @@
 
 ## 1.3.1
 
-* Added more components to local demo to test mobile search positioning 
+* Added more components to local demo to test mobile search positioning
 
 ## 1.3.0
 
-* Added `myuw-search` CustomEvent that exposes the value in the search field when a search is submitted
+* Added `myuw-search` CustomEvent that exposes the value in the search field
+  when a search is submitted
 
 ## 1.2.4
 
-* Added CSS variable to explicitly set mobile search bar origin position (sets the value of `right`).
+* Added CSS variable to explicitly set mobile search bar origin position
+  (sets the value of `right`).
 
 ## 1.2.3
 
-### Added 
+### Added
 
 * Responsive theming support
 
@@ -22,7 +24,8 @@
 
 ### Added
 
-* Now supports setting the `--myuw-search-border` CSS variable to better support theming.
+* Now supports setting the `--myuw-search-border` CSS variable to better
+  support theming.
 
 ## Changed
 
@@ -30,4 +33,5 @@
 
 ## 1.1.8
 
-This patch adds attribute mirroring so that changes to observed attributes that occur _after_ the initial load are correctly reflected in the component.
+This patch adds attribute mirroring so that changes to observed attributes
+that occur _after_ the initial load are correctly reflected in the component.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,31 @@
 # Contributing
 
-When contributing to this repository, please first discuss the change you wish to make via issue,
-email, in person, or any other method with the owners of this repository before making a change.
+When contributing to this repository, please first discuss the change you wish
+to make via issue, email, in person, or any other method with the owners of this
+repository before making a change.
 
-Please note we have a code of conduct, please follow it in all your interactions with the project.
+Please note we have a code of conduct, please follow it in all your interactions
+with the project.
 
 ## Pull Request Process
 
 1. Ensure any build or configuration artifacts are removed before submission
-2. Increase the version number to the new version that this Pull Request would represent.
+2. Increase the version number to the new version that this Pull Request would
+  represent.
 3. Update the README.md with relevant details of the change.
-   variables, exposed ports, etc.
-   The versioning scheme we use is [SemVer](http://semver.org/).
-4. Open a pull request from your fork to the upstream master branch.  Include 'WIP' in the title
-   if the changeset is not yet ready to merge and use in production settings.  Remove it once finalized.
-5. Squash commits to the smallest meaningful number of revisions.  Do not include merge commits.
-6. Fully test the change—collaborating with maintainers as necessary—before merging the pull request.
-7. You may merge the Pull Request in once you feel comfortable with it and have the sign-off of at
-   least one other developer, or if you do not have permission to do that, you may request the
-   reviewer to merge it for you.
+  variables, exposed ports, etc.
+  The versioning scheme we use is [SemVer](http://semver.org/).
+4. Open a pull request from your fork to the upstream master branch.  Include
+  'WIP' in the title if the changeset is not yet ready to merge and use in
+  production settings.
+  Remove it once finalized.
+5. Squash commits to the smallest meaningful number of revisions.
+  Do not include merge commits.
+6. Fully test the change—collaborating with maintainers as necessary—before
+  merging the pull request.
+7. You may merge the Pull Request in once you feel comfortable with it and have
+  the sign-off of at least one other developer, or if you do not have permission
+  to do that, you may request the reviewer to merge it for you.
 
 ## Code of Conduct
 
@@ -27,9 +34,9 @@ Please note we have a code of conduct, please follow it in all your interactions
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
+size, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
 
 ### Our Standards
 
@@ -80,8 +87,9 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team by [email][email]. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+obligated to maintain confidentiality with regard to the reporter of an
+incident. Further details of specific enforcement policies may be posted
+separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
@@ -89,8 +97,8 @@ members of the project's leadership.
 
 ### Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
 
 [email]: mailto:info@my.wisc.edu
 [homepage]: http://contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 When contributing to this repository, consider first discussing the change you
 wish to make via issue, email, in person, or any other method with the owners of
-this repository before making a change. That said, sometimes a Pull Request is
-the most effective way to communicate an idea and it's fine to lead with a Pull
-Request so long as you're open to discussion from there.
+this repository. That said, sometimes a Pull Request is the most effective way
+to communicate an idea and it's fine to lead with a Pull Request so long as
+you're open to discussion from there.
 
 Please note we have a code of conduct, please follow it in all your interactions
 with the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,13 @@ you're open to discussion from there.
 Please note we have a code of conduct, please follow it in all your interactions
 with the project.
 
+**All of the technical guidance here is on a try-your-best basis.**
+All anyone can ask is that you try your best. Definitely do not let code
+formatting or organizing your commits just so or questions about Semantic
+Versioning or anything else be a barrier to contributing. Maintainers can help
+you work through all of that and more in collaborating on your contribution,
+and if need be can post-process contributions to smooth out rough edges.
+
 ## Pull Request Process
 
 1. Ensure any build or configuration artifacts are removed before submission

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,11 @@ with the project.
   represent. This product uses [SemVer](http://semver.org/).
 3. Update the README.md with relevant details of the change.
   variables, exposed ports, etc.
-4. Open a pull request from your fork to the upstream master branch.  Include
-  'WIP' in the title if the changeset is not yet ready to merge and use in
-  production settings.
-  Remove it once finalized.
+4. Open a pull request from your fork to the upstream master branch.
+  Communicate that the Pull Request is a work-in-progress if it is not yet ready
+  to merge and use in production settings, by using
+  [GitHub's draft Pull Requests feature][] or prepending "WIP: " to the Pull
+  Request title.
 5. Squash commits to the smallest meaningful number of revisions.
   Do not include merge commits.
 6. Fully test the change—collaborating with maintainers as necessary—before
@@ -104,3 +105,5 @@ version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
 [email]: mailto:info@my.wisc.edu
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/
+
+[GitHub's draft Pull Requests feature]: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,9 @@ with the project.
 
 1. Ensure any build or configuration artifacts are removed before submission
 2. Increase the version number to the new version that this Pull Request would
-  represent.
+  represent. This product uses [SemVer](http://semver.org/).
 3. Update the README.md with relevant details of the change.
   variables, exposed ports, etc.
-  The versioning scheme we use is [SemVer](http://semver.org/).
 4. Open a pull request from your fork to the upstream master branch.  Include
   'WIP' in the title if the changeset is not yet ready to merge and use in
   production settings.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,10 @@
 # Contributing
 
-When contributing to this repository, please first discuss the change you wish
-to make via issue, email, in person, or any other method with the owners of this
-repository before making a change.
+When contributing to this repository, consider first discussing the change you
+wish to make via issue, email, in person, or any other method with the owners of
+this repository before making a change. That said, sometimes a Pull Request is
+the most effective way to communicate an idea and it's fine to lead with a Pull
+Request so long as you're open to discussion from there.
 
 Please note we have a code of conduct, please follow it in all your interactions
 with the project.


### PR DESCRIPTION
Motivation: was reminded of and read the contributing docs, which are pretty good, but the prescribe some details that don't resonate with me, so attempting to nudge the culture a bit to be less prescriptive of practices I think aren't always the best-fit practices.

NB: This touches files that the other pending PR #23 may touch, so might be wise to hold off on merging this until that merges or at least to be intentional about where to incur and resolve the likely merge conflicts.

## Substantive changes

+ Express openness to a Pull Request as the way a contribution is communicated and discussed, not necessarily requiring additional communication in another channel where this adds more noise than signal.
+ Emphasize welcoming best-efforts contributions
+ Suggest GitHub's draft pull requests feature to express work-in-progress-ness

## Style

Wraps Markdown files at 80 characters, updating .editorconfig to document this style.

## Copy edits

Copy edits for brevity and clarity.
