### PR TITLE
Make Submit search button more prominent when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # myuw-search versions
 
+## 1.5.1
+
+* Added default aria-disabled to Submit Search button
+* Added click event listeners for search input
+* Inform assistive technologies users when submitting empty search form and when searching begins by adjusting aria-live="assertive"
+
 ## 1.5.0
 
 * Added role='search' to the search form

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-search",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-search",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A material search field made for use with MyUW web components",
   "module": "dist/myuw-search.min.mjs",
   "browser": "dist/myuw-search.min.js",

--- a/src/myuw-search.html
+++ b/src/myuw-search.html
@@ -74,6 +74,26 @@
     #icon {
         color: #333;
     }
+
+   .visually-hidden {
+      position: absolute !important;
+      overflow: hidden;
+      height: 1px;
+      width: 1px;
+      word-wrap: normal;
+    }
+
+    button[disabled],
+    button[aria-disabled=true] {
+      background-color: #f3f3f3 !important;
+      pointer-events: none;
+    }
+
+    button[disabled],
+    button[aria-disabled=true] #icon{
+      opacity: 0.5;
+    }
+
     @media screen, \0 all, \\0 screen {
       @media (max-width: 600px) {
         :host,
@@ -174,7 +194,8 @@
         <i id='iconToggle' class='material-icons'></i>
     </button>
     <input id='input' name='myuw-search-input' aria-label='' type='text' placeholder=''/>
-    <button id='submit' aria-label='' type='submit' aria-live="assertive">
+    <button aria-disabled="true" id='submit' aria-label='' type='submit'>
         <i id='icon' class='material-icons'></i>
     </button>
+    <p class="visually-hidden" aria-live="assertive"></p>
 </form>

--- a/src/myuw-search.js
+++ b/src/myuw-search.js
@@ -47,7 +47,8 @@ export class MyUWSearch extends HTMLElement {
         this.$button        = this.shadowRoot.querySelector('button#submit');
         this.$toggle        = this.shadowRoot.querySelector('button#toggle');
         this.$toggleIcon    = this.shadowRoot.querySelector('i#iconToggle');
-        
+        this.nonVisualHint  = this.shadowRoot.querySelector('.visually-hidden');
+
         // Set icon and label values
         this.$icon.innerText = this.icon;
         this.$toggleIcon.innerText = this.icon;
@@ -59,6 +60,15 @@ export class MyUWSearch extends HTMLElement {
         // Get viewport width and toggle button position
         // this.$cssWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
         // this.$togglePosition = this.$toggle.getBoundingClientRect();
+
+        // Add click event listeners for search input text
+        this.$input.addEventListener('keyup', e => {
+          if (this.$input.value.length > 0) {
+            this.$button.setAttribute('aria-disabled', 'false');
+          } else {
+            this.$button.setAttribute('aria-disabled', 'true');
+          }
+        });
 
         // Add click event listeners for submit and toggle buttons
         this.$button.addEventListener('click', e => {
@@ -117,6 +127,13 @@ export class MyUWSearch extends HTMLElement {
     submitSearch(event) {
         event.preventDefault();
         event.stopPropagation();
+
+        // Add assistive technologies hint message when submitting search request
+        if (this.$input.value.length > 0) {
+            this.nonVisualHint.innerHTML = 'Searching for ' + this.$input.value;
+          } else {
+            this.nonVisualHint.innerHTML = 'Search field is empty.';
+          }
 
         // Using `callback` property:
         if (this.callback && typeof this.callback === 'function') {


### PR DESCRIPTION
**1.5.1**

- Set aria-disabled="true" by default when no search term is entered into the search input
- Add style rules to make Submit Search button more prominent when in disabled state
- Add aria-live message for assistive technologies users, when submitting the search form:
`Searching for  + this.$input.value`, and `Search field is empty.` when submitting without a value.
<img width="444" alt="Screen Shot 2020-04-07 at 7 16 40 AM" src="https://user-images.githubusercontent.com/10341961/78668146-c47ed100-789f-11ea-8187-02ff5bfb7cbb.png">
