### PR TITLE
Fix failing form submission on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # myuw-search versions
 
+## 1.5.5
+
+* Fix failing form submission on mobile
+* Accessibility fix: add focus style on search button
+
 ## 1.5.4
 
 * Adjustments to the position of the Search icon on mobile views

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-search",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-search",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "A material search field made for use with MyUW web components",
   "module": "dist/myuw-search.min.mjs",
   "browser": "dist/myuw-search.min.js",

--- a/src/myuw-search.html
+++ b/src/myuw-search.html
@@ -83,6 +83,10 @@
       word-wrap: normal;
     }
 
+    .hiddenElement {
+      display: none !important;
+    }
+
     button[disabled],
     button[aria-disabled=true] {
       background-color: #f3f3f3 !important;
@@ -100,14 +104,15 @@
         myuw-search {
             border: none;
         }
+        #submit {
+          display:none;
+        }
         #form {
             justify-content: flex-end;
             padding: 0;
             align-items: center;
         }
-        #submit {
-            display: none;
-        }
+
         #input {
             width: 0;
             max-width: 0;
@@ -119,6 +124,7 @@
             opacity: 0;
             transition: opacity .4s cubic-bezier(.25, .8, .25, 1);
         }
+
         #toggle {
             display: flex;
             transition: background 0.2s cubic-bezier(.25, .8, .25, 1);
@@ -134,10 +140,15 @@
             cursor: pointer;
             outline: none;
             justify-content: center;
-
         }
+
         #toggle:hover {
             background: rgba(0, 0, 0, 0.2);
+        }
+
+        #toggle:focus {
+            outline: 2px solid #5e9ed6;
+            outline: -webkit-focus-ring-color auto 5px;
         }
 
         #iconToggle {
@@ -172,30 +183,38 @@
             max-width: none;
             padding: 0 16px;
         }
-        #form[expanded] #toggle {
+         #form[expanded] #submit {
+            display: block;
             position: absolute;
             right: 0;
-            margin: 0 6px;
             background: transparent;
+            height: 100%;
         }
-        #form[expanded] #toggle:hover {
+        #form[expanded] #submit:hover {
             background: rgba(0,0,0,0.12);
             opacity: 1;
         }
-        #form[expanded] #iconToggle {
+        #form[expanded] #icon {
             color: #000;
             background: transparent;
+            top: 16px;
         }
     }
   }
 </style>
 <form id='form' role='search' class='myuw-search-container' onsubmit='$event.preventDefault(); submitSearch($event)'>
-    <button id='toggle' aria-label='' type='button'>
+
+    <!-- Mobile button to toggle search input -->
+    <button id='toggle' aria-label='Show search input' type='button'>
         <i id='iconToggle' class='material-icons'></i>
     </button>
+
     <input id='input' name='myuw-search-input' aria-label='' type='text' placeholder=''/>
+
+    <!-- Submit search form button -->
     <button aria-disabled="true" id='submit' aria-label='' type='submit'>
         <i id='icon' class='material-icons'></i>
     </button>
+
     <p class="visually-hidden" aria-live="assertive"></p>
 </form>

--- a/src/myuw-search.js
+++ b/src/myuw-search.js
@@ -55,7 +55,6 @@ export class MyUWSearch extends HTMLElement {
         this.$input.setAttribute('aria-label', this.inputLabel);
         this.$input.setAttribute('placeholder', this.inputLabel);
         this.$button.setAttribute('aria-label', this.buttonLabel);
-        this.$toggle.setAttribute('aria-label', 'show search');
 
         // Get viewport width and toggle button position
         // this.$cssWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
@@ -73,6 +72,9 @@ export class MyUWSearch extends HTMLElement {
         // Add click event listeners for submit and toggle buttons
         this.$button.addEventListener('click', e => {
             this.submitSearch(e);
+            if (this.$form.hasAttribute('expanded')) {
+               this.toggleSearch(e);
+            }
         });
         
         this.$toggle.addEventListener('click', e => {
@@ -103,12 +105,12 @@ export class MyUWSearch extends HTMLElement {
         switch (attribute) {
             case 'input-label':
                 if (this.$input) {
-                    this.$input.setAttribute('placeholder', value);    
+                    this.$input.setAttribute('placeholder', value);
                 }
                 break;
             case 'button-label':
                 if (this.$button) {
-                    this.$button.setAttribute('aria-label', value);    
+                    this.$button.setAttribute('aria-label', value);
                 }
                 break;
             case 'icon':
@@ -156,10 +158,10 @@ export class MyUWSearch extends HTMLElement {
     toggleSearch(event) {
         // Get viewport width and position of toggle button
         this.$cssWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
-        this.$togglePosition = this.$toggle.getBoundingClientRect();
-
+//        this.$togglePosition = this.$toggle.getBoundingClientRect();
+         this.$submitPosition = this.$button.getBoundingClientRect(); //newline
         // Get value for 'right' positioning of form anchor (minus width of button)
-        var right = Math.floor(this.$cssWidth - this.$togglePosition.left - 42);
+        var right = Math.floor(this.$cssWidth - this.$submitPosition.left - 42);
 
         // Set positioning
         this.$form.style.right = right;
@@ -167,12 +169,12 @@ export class MyUWSearch extends HTMLElement {
         // Set icon for toggle button and expand form
         if (this.$form.hasAttribute('expanded')) {
             this.$form.removeAttribute('expanded');
-            this.$toggleIcon.innerText = this.icon;
-            this.$toggle.setAttribute('aria-label', 'show search');
+            this.$icon.innerText = this.icon;
+            this.$toggle.setAttribute('class', '');
         } else {
             this.$form.setAttribute('expanded', 'true');
-            this.$toggleIcon.innerText = 'arrow_forward';
-            this.$toggle.setAttribute('aria-label', 'close search');
+            this.$toggle.setAttribute('class', 'hiddenElement');
+            this.$icon.innerText = 'arrow_forward';
         }
     }
 }


### PR DESCRIPTION
## 1.5.5

* Fix failing form submission on mobile
* Accessibility fix: add focus style on search button

This is a fix for the issue discovered by MyUW team. The search form was failing to return any results on mobile devices. It turns out that the Submit search button on mobile views wasn't connected to the functionality responsible for submitting the search query.

Previously, the button (magnifying glass) responsible for showing the search input on mobile, was the same one that was supposed to submit the search on mobile. But it wasn't connected to that functionality at all. 

To fix this, instead of hiding the working Submit search button on mobile views, I refactor it to be also used on mobile search input. And the button responsible for showing the search form will only be responsible for that one thing and be hidden when the search input is shown.

